### PR TITLE
Subcommand help, and more natural many-party introductions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,31 +6,31 @@ Introbot is a quick python script to write an introductory e-mail between n part
 add a person
 ------------
 
-Add a person with the `-a` switch. A person has a nickname, a firstname, and a description.
+Add a person with the `add` subcommand. A person has a nickname, a firstname, and a description.
 
 For example:
 
-    python intro.py -a hilary "Hilary thinks you should write scripts to do things instead of just doing them."
-    
+    python intro.py add hilary "Hilary thinks you should write scripts to do things instead of just doing them."
+
 If the nickname that you want to use is the same as their first name, that's it. If you want to use a different nickname, just specify all three in order (nickname, name, and description):
 
-    python intro.py -a mason Hilary "Hilary thinks..."
-    
+    python intro.py add mason Hilary "Hilary thinks..."
+
 voila!
 
 write an intro
 --------------
 
-To create an intro, just give the nicknames of the people you would like to introduce.
+To create an intro, use the `intro` subcommand and give the nicknames of the people you would like to introduce.
 
-    python intro.py hilary pete
-    
+    python intro.py intro hilary pete
+
 The script will generate the intro, print it to STDOUT, and, on a Mac, copy it to your clipboard. Paste it into your favorite e-mail client and take a dramatic sip of coffee.
 
 You can also create an intro with a custom message:
 
-    python intro.py hilary pete -m "You both love sculpture, you should definitely find a time to talk."
-    
+    python intro.py intro hilary pete -m "You both love sculpture, you should definitely find a time to talk."
+
 disclaimers
 -----------
 


### PR DESCRIPTION
Ported argument parsing to `argparse` (requires Python 2.7+) so that subcommands could be given separate help and parameter validation. Not sure whether the extra subcommand argument makes the script harder to use or not.

Also, changed the way that multiparty introductions are done, so instead of "Alice & Bob & Carol", it's "Alice, Bob & Carol".
